### PR TITLE
Fix zalgo's minimum and maximum usage

### DIFF
--- a/plover_fancytext/zalgo.py
+++ b/plover_fancytext/zalgo.py
@@ -24,12 +24,12 @@ class Zalgo(FormatterBase):
         if c in self.translations:
             return self.translations[c]
 
+        o = c
         for m in random.sample(
                 COMBINING_MARKS,
                 random.randrange(self.minimum, self.maximum)):
-            o = c
             o += m
-            self.translations[c] = o
+        self.translations[c] = o
         return o
 
     def format(self, str) -> str:


### PR DESCRIPTION
The combining marks were being overwritten every loop, so only the last one in the loop was kept. Regardless of minimum and maximum, it only ever added one combining mark to each letter. I just moved the creation base letter to above the loop, and moved adding of the fully combined form to the translations dictionary to below the loop.